### PR TITLE
Fix crash on http client teardown: um_http_close()

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: test
       working-directory: ${{runner.workspace}}/build
-      run: ./test/all_tests -r xunit -o ./Testing/report.xml
+      run: ./tests/all_tests -r xunit -o ./Testing/report.xml
       env:
         UM_TEST_DEBUG: 7
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,6 +23,11 @@ jobs:
             openssl: on
 
     steps:
+    - name: Install tools
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        apt install -y valgrind
+
     - uses: actions/checkout@v2
       with:
         fetch-depth: '0'
@@ -41,7 +46,7 @@ jobs:
 
     - name: Memory Check
       working-directory: ${{runner.workspace}}/build
-      if: always()
+      if: always() && matrix.os == 'ubuntu-latest'
       run: ctest --no-compress-output -T MemCheck
       env:
         UM_TEST_DEBUG: 7

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,13 +35,19 @@ jobs:
 
     - name: test
       working-directory: ${{runner.workspace}}/build
-      run: ctest -VV --no-compress-output -T Test
+      run: ./test/all_tests -r xunit -o ./Testing/report.xml
+      env:
+        UM_TEST_DEBUG: 7
+
+    - name: Memory Check
+      working-directory: ${{runner.workspace}}/build
+      run: ctest --no-compress-output -T MemCheck
       env:
         UM_TEST_DEBUG: 7
 
     - name: upload test report
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3.1
       with:
         name: ${{ matrix.os }}-TestReport
-        path: ${{runner.workspace}}/build/Testing/*/Test.xml
+        path: ${{runner.workspace}}/build/Testing/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,13 +31,16 @@ jobs:
     - name: configure cmake
       run: cmake -S ${{ github.workspace }} -B ${{runner.workspace}}/build -DUSE_OPENSSL=${{ matrix.openssl }}
     - name: build 
-      run: cmake --build ${{runner.workspace}}/build 
+      run: cmake --build ${{runner.workspace}}/build
+
     - name: test
       working-directory: ${{runner.workspace}}/build
       run: ctest -VV --no-compress-output -T Test
       env:
         UM_TEST_DEBUG: 7
+
     - name: upload test report
+      if: always()
       uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}-TestReport

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: test
       working-directory: ${{runner.workspace}}/build
-      run: ./tests/all_tests -r xml -o ./Testing/report.xml
+      run: cmake --build . --target run-tests
       env:
         UM_TEST_DEBUG: 7
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,12 +35,13 @@ jobs:
 
     - name: test
       working-directory: ${{runner.workspace}}/build
-      run: ./tests/all_tests -r xunit -o ./Testing/report.xml
+      run: ./tests/all_tests -r xml -o ./Testing/report.xml
       env:
         UM_TEST_DEBUG: 7
 
     - name: Memory Check
       working-directory: ${{runner.workspace}}/build
+      if: always()
       run: ctest --no-compress-output -T MemCheck
       env:
         UM_TEST_DEBUG: 7

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -55,5 +55,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: ${{ matrix.os }}-TestReport
+        name: ${{ matrix.os }}-${{ matrix.openssl }}-TestReport
         path: ${{runner.workspace}}/build/Testing/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,7 @@ jobs:
 
     - name: upload test report
       if: always()
-      uses: actions/upload-artifact@v3.1
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}-TestReport
         path: ${{runner.workspace}}/build/Testing/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install tools
       if: matrix.os == 'ubuntu-latest'
       run: |
-        apt install -y valgrind
+        sudo apt install -y valgrind
 
     - uses: actions/checkout@v2
       with:

--- a/sample/http-ping.c
+++ b/sample/http-ping.c
@@ -2,14 +2,34 @@
 #include <uv_mbed/um_http.h>
 #include <uv_mbed/uv_mbed.h>
 
+static struct opts {
+    int keepalive;
+    int timeout;
+    int ping_count;
+    int delay;
+} opts = {
+        .keepalive = 10000,
+        .timeout = 1000,
+        .delay = 2000,
+        .ping_count = 3,
+};
+
 static void on_response(um_http_resp_t *resp, void* ctx) {
     printf("%d %s\n", resp->code, resp->status);
+}
+
+static void on_clt_close(um_http_t* http) {
+    printf("HTTP is closed\n");
 }
 
 static void do_request(uv_timer_t *t) {
     um_http_t *http = t->data;
 
     um_http_req(http, "GET", "/json", on_response, NULL);
+    if (--opts.ping_count <= 0) {
+        uv_close((uv_handle_t *) t, NULL);
+        um_http_close(http, on_clt_close);
+    }
 }
 
 void logger(int level, const char *file, unsigned int line, const char *msg) {
@@ -25,13 +45,13 @@ int main(int argc, char *argv[]) {
     uv_loop_t *l = uv_default_loop();
     um_http_t http;
     um_http_init(l, &http, "https://httpbin.org");
-    um_http_idle_keepalive(&http, 1);
-    um_http_connect_timeout(&http, 3000);
+    um_http_idle_keepalive(&http, opts.keepalive);
+    um_http_connect_timeout(&http, opts.timeout);
 
     uv_timer_t timer;
     uv_timer_init(l, &timer);
     timer.data = &http;
 
-    uv_timer_start(&timer, do_request, 0, 10000);
+    uv_timer_start(&timer, do_request, 0, opts.delay);
     uv_run(l, UV_RUN_DEFAULT);
 }

--- a/src/http.c
+++ b/src/http.c
@@ -417,10 +417,6 @@ int um_http_close(um_http_t *clt, um_http_close_cb close_cb) {
     fail_active_request(clt, UV_ECANCELED, uv_strerror(UV_ECANCELED));
     close_connection(clt);
 
-    if (clt->src != NULL) { 
-        clt->src->release(clt->src);
-    }
-
     if (clt->engine != NULL) {
         clt->tls->api->free_engine(clt->engine);
         clt->engine = NULL;

--- a/src/tcp_src.c
+++ b/src/tcp_src.c
@@ -62,7 +62,8 @@ static void tcp_connect_cb(uv_connect_t *req, int status) {
 
     if (sl == NULL) {
         UM_LOG(TRACE, "connect requests was cancelled");
-        uv_close((uv_handle_t *) req->handle, free_handle);
+        if (!uv_is_closing((const uv_handle_t *) req->handle))
+            uv_close((uv_handle_t *) req->handle, free_handle);
         free(req);
         return;
     }
@@ -174,6 +175,7 @@ static void tcp_src_cancel(um_src_t *sl) {
     }
 
     if (tl->conn_req) {
+        uv_tcp_close_reset((uv_tcp_t *) tl->conn_req->handle, free_handle);
         tl->conn_req->data = NULL;
         tl->conn_req = NULL;
     }

--- a/src/uv_mbed.c
+++ b/src/uv_mbed.c
@@ -87,11 +87,7 @@ static void on_mbed_close(uv_link_t *l) {
 
 int uv_mbed_close(uv_mbed_t *mbed, uv_close_cb close_cb) {
     mbed->close_cb = close_cb;
-    if (mbed->parent)
-        uv_link_propagate_close((uv_link_t *) mbed, (uv_link_t *) mbed, on_mbed_close);
-    else {
-        on_mbed_close((uv_link_t *) mbed);
-    }
+    uv_link_propagate_close((uv_link_t *) mbed, (uv_link_t *) mbed, on_mbed_close);
     return 0;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,10 @@ target_link_libraries(all_tests
 
 target_include_directories(all_tests PRIVATE ../src)
 
+add_custom_target(run-tests
+        BYPRODUCTS ${PROJECT_BINARY_DIR}/Testing/results.xml
+        DEPENDS all_tests
+        COMMAND $<TARGET_FILE:all_tests> -r xml -o ${PROJECT_BINARY_DIR}/Testing/results.xml)
 #find_program(MEMORYCHECK_COMMAND valgrindor)
 #set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full" )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,8 +20,6 @@ add_custom_target(run-tests
         BYPRODUCTS ${PROJECT_BINARY_DIR}/Testing/results.xml
         DEPENDS all_tests
         COMMAND $<TARGET_FILE:all_tests> -r xml -o ${PROJECT_BINARY_DIR}/Testing/results.xml)
-#find_program(MEMORYCHECK_COMMAND valgrindor)
-#set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full" )
 
 include(CTest)
 add_test(engine_tests all_tests [engine])

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(all_tests
 
 target_include_directories(all_tests PRIVATE ../src)
 
+#find_program(MEMORYCHECK_COMMAND valgrindor)
+#set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full" )
+
 include(CTest)
 add_test(engine_tests all_tests [engine])
 add_test(http_tests all_tests [http])

--- a/tests/engine_tests.cpp
+++ b/tests/engine_tests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("key gen", "[engine]") {
 
     tls_private_key k1;
     char *pem2;
-    REQUIRE(ctx->api->load_key(&k1, pem, pemlen) > 0);
+    REQUIRE(ctx->api->load_key(&k1, pem, pemlen) == 0);
     REQUIRE(ctx->api->write_key_to_pem(key, &pem2, &pemlen) == 0);
 
     REQUIRE_THAT(pem2, Catch::Matchers::Equals(pem));

--- a/tests/engine_tests.cpp
+++ b/tests/engine_tests.cpp
@@ -39,7 +39,7 @@ TEST_CASE("key gen", "[engine]") {
 
     tls_private_key k1;
     char *pem2;
-    REQUIRE(ctx->api->load_key(&k1, pem, pemlen) == 0);
+    REQUIRE(ctx->api->load_key(&k1, pem, pemlen) > 0);
     REQUIRE(ctx->api->write_key_to_pem(key, &pem2, &pemlen) == 0);
 
     REQUIRE_THAT(pem2, Catch::Matchers::Equals(pem));


### PR DESCRIPTION
this PR also:
- fixes test results collection in CI
- runs tests in MemCheck (valgrind) in CI on Linux