### PR TITLE
allow building from downloaded source bundle

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+version.txt export-subst

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,7 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
 
-execute_process(
-        COMMAND git describe --tags HEAD
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE GIT_INFO
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-if(${GIT_INFO} MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)$")
-    set(ver ${CMAKE_MATCH_1})
-elseif(${GIT_INFO} MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)-([0-9]+)-[^-]*")
-    string(JOIN "." ver ${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
-endif()
+include(cmake/version.cmake)
+get_version(${CMAKE_CURRENT_LIST_DIR}/version.txt ver)
 
 PROJECT("uv-mbed"
         LANGUAGES C

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -1,0 +1,29 @@
+
+function(get_version version_file version_var)
+    execute_process(
+            COMMAND git describe --tags HEAD
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            OUTPUT_VARIABLE GIT_INFO
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_VARIABLE git_error
+    )
+
+    if (git_error)
+        unset(GIT_INFO)
+        message("getting version from ${version_file}")
+        file(STRINGS ${version_file} ver_info)
+        list(LENGTH ver_info ver_info_len)
+        message("ver_info_len = ${ver_info_len}")
+        message(${ver_info})
+        list(GET ver_info 0 GIT_INFO)
+
+    endif ()
+
+    if (${GIT_INFO} MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)$")
+        set(_ver ${CMAKE_MATCH_1})
+    elseif (${GIT_INFO} MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)-([0-9]+)-[^-]*")
+        string(JOIN "." _ver ${CMAKE_MATCH_1} ${CMAKE_MATCH_2})
+    endif ()
+
+    set(${version_var} ${_ver} PARENT_SCOPE)
+endfunction()

--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -13,10 +13,7 @@ function(get_version version_file version_var)
         message("getting version from ${version_file}")
         file(STRINGS ${version_file} ver_info)
         list(LENGTH ver_info ver_info_len)
-        message("ver_info_len = ${ver_info_len}")
-        message(${ver_info})
         list(GET ver_info 0 GIT_INFO)
-
     endif ()
 
     if (${GIT_INFO} MATCHES "^v([0-9]+\\.[0-9]+\\.[0-9]+)$")

--- a/version.txt
+++ b/version.txt
@@ -1,3 +1,3 @@
-$Format: %d$
-$Format: %D$
-$Format: %(describe)$
+$Format: %(describe:tags)$
+ref: $Format: %D$
+hash: $Format: %h$

--- a/version.txt
+++ b/version.txt
@@ -1,0 +1,3 @@
+$Format: %d$
+$Format: %D$
+$Format: %(describe)$


### PR DESCRIPTION
version.txt is populated by git-archive process that creates the source bundle
cmake config is modified to read version from file if source tree is not a git repo